### PR TITLE
handle ArgumentNullException on collection

### DIFF
--- a/api/Crt.Data/Repositories/ProjectRepository.cs
+++ b/api/Crt.Data/Repositories/ProjectRepository.cs
@@ -76,7 +76,7 @@ namespace Crt.Data.Repositories
                     .Include(x => x.WinningCntrctrLkup)
                     .Where(x => x.ProjectId == result.ProjectId && x.WinningCntrctrLkupId != null)
                     .OrderBy(x => x.DbAuditLastUpdateTimestamp)
-                    .FirstOrDefault().WinningCntrctrLkup.CodeName;
+                    .FirstOrDefault()?.WinningCntrctrLkup.CodeName;
                 
                 result.WinningContractorName = winningContractor;
 


### PR DESCRIPTION
Winning Contractor may not exist and the ArumentNullException needs to be handled before operating on the collection