### PR TITLE
0.5

### DIFF
--- a/client/src/js/components/forms/EditAnnouncementFormFields.js
+++ b/client/src/js/components/forms/EditAnnouncementFormFields.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import _ from 'lodash';
 import * as Yup from 'yup';
 
 import PageSpinner from '../ui/PageSpinner';
@@ -27,9 +28,10 @@ const EditAnnouncementFormFields = ({ setInitialValues, formValues, setValidatio
       api
         .getProject(projectId)
         .then((response) => {
+          let data = _.omitBy(response.data, _.isNil);
           setInitialValues({
-            ...response.data,
-            anncmentComment: response.data.anncmentComment || '',
+            ...defaultValues,
+            ...data,
           });
           setLoading(false);
         })

--- a/client/src/js/components/forms/FormInputs.js
+++ b/client/src/js/components/forms/FormInputs.js
@@ -45,16 +45,17 @@ export const FormInput = ({ children, ...props }) => {
 
 export const FormNumberInput = ({ className, children, ...props }) => {
   const [field, meta, helpers] = useField({ ...props, type: 'checkbox' });
+
   return (
     <React.Fragment>
       <Input type="hidden" {...field} {...props} invalid={meta.error && meta.touched} />
       <NumberFormat
         className={classNames('form-control', className)}
         thousandSeparator={true}
-        value={props.value}
+        value={props.value || undefined}
         onValueChange={(val) => {
           helpers.setTouched(true);
-          helpers.setValue(val.floatValue || 0);
+          helpers.setValue(val.floatValue);
         }}
         {...props}
       >

--- a/client/src/js/components/project/ProjectPlan.js
+++ b/client/src/js/components/project/ProjectPlan.js
@@ -280,11 +280,15 @@ const ProjectPlan = ({ match, history, fiscalYears, phases, showValidationErrorD
         <DisplayRow>
           <ColumnTwoGroups
             name="Announcement Value"
-            label={<NumberFormat value={data?.anncmentValue} prefix="$" thousandSeparator={true} displayType="text" />}
+            label={
+              <NumberFormat value={data?.anncmentValue || ''} prefix="$" thousandSeparator={true} displayType="text" />
+            }
           />
           <ColumnTwoGroups
             name="C-035 Value"
-            label={<NumberFormat value={data?.c035Value} prefix="$" thousandSeparator={true} displayType="text" />}
+            label={
+              <NumberFormat value={data?.c035Value || ''} prefix="$" thousandSeparator={true} displayType="text" />
+            }
           />
         </DisplayRow>
         <DisplayRow>


### PR DESCRIPTION
fixed bugs with 0 not being wiped clean on numberFormat fields. 
Null values causing console warnings for public project information. 
Also fixed bug where putting in empty values into public project information would not update the value. 

With the way input and numberFormat interacts in formik, there is remaining console.warning bug. 

steps to recreate. 
Go to public project information. Located at Project Plan. 
Click edit 
Have dev tools open in Chrome at the Console tab. 
remove all values from the number field. 
Should see the following error. 
![image](https://user-images.githubusercontent.com/74216496/110837930-b4f9cc00-8256-11eb-9c12-6f2af352a4be.png)

This is due to the value undefined being set to Input causing the component to become uncontrolled. Still looking for a solution. For now it does not affect the functionality of the application. 