### PR TITLE
fixed bug codesets

### DIFF
--- a/client/src/js/components/forms/EditCodeSetFormFields.js
+++ b/client/src/js/components/forms/EditCodeSetFormFields.js
@@ -7,7 +7,7 @@ import { FormRow, FormInput } from './FormInputs';
 import * as Constants from '../../Constants';
 import * as api from '../../Api';
 
-const defaultValues = { codeValueText: '', codeName: '', displayOrder: undefined };
+const defaultValues = { codeValueText: '', codeName: '', displayOrder: 0 };
 
 const EditCodeSetFormFields = ({
   setInitialValues,
@@ -24,6 +24,7 @@ const EditCodeSetFormFields = ({
   });
 
   useEffect(() => {
+    debugger;
     setInitialValues(defaultValues);
     setValidationSchema(validationSchema);
 


### PR DESCRIPTION
 where clicking edit and then adding would show the display order from the edited value. Display order now defaults to 0 to address this. 
 
steps to recreate: 
default value for displayOrder is undefined
for input type Number. 
click edit (should show dialog with displayOrder Num) 
click add displayOrder will be the edit Num. 