### PR TITLE
Hot Fix: truncate username to 30 chars for APP_CREATE/LAST_UPDATE_USERID

### DIFF
--- a/api/Crt.Api/Authentication/CrtJwtBearerEvents.cs
+++ b/api/Crt.Api/Authentication/CrtJwtBearerEvents.cs
@@ -108,7 +108,7 @@ namespace Crt.Api.Authentication
             }
 
             _curentUser.UserGuid = userGuid;
-            _curentUser.Username = username;
+            _curentUser.Username = username.Length > 30 ? username[..30] : username;
             _curentUser.Email = email;
             _curentUser.FirstName = user.FirstName;
             _curentUser.LastName = user.LastName;


### PR DESCRIPTION
PR #542 correctly removed the hardcoded isApiClient=true bypass, but IDIR users now have their preferred_username GUID (36 chars) written directly into AppCreateUserid / AppLastUpdateUserid columns (VARCHAR 30), causing SQL error 8152 'String or binary data would be truncated' on every SaveChanges().

Cap _curentUser.Username at 30 characters before assignment so it fits the audit column constraint across all tables.

---

Thanks for the PR!

After merge, new images are deployed and promoted to DEV:
- [DEV Homepage](https://crt-554.apps.silver.devops.gov.bc.ca)